### PR TITLE
Remove unwrap and satisfy clippy.

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -10,17 +10,23 @@ enum PyVer {
     },
 }
 
-fn command_list(root: Option<String>) {
-    let pyver_root = root.ok_or(env::var("PYVER_ROOT")).unwrap();
-    for entry in fs::read_dir(pyver_root).unwrap() {
-        let path = entry.unwrap().path();
-        println!("{}", path.file_name().unwrap().to_str().unwrap());
+fn command_list(maybe_root: Option<String>) -> Result<(), Box<dyn std::error::Error>> {
+    let pyver_root = match maybe_root {
+        Some(pyver_root) => pyver_root,
+        None => env::var("PYVER_ROOT")?
+    };
+    for entry in fs::read_dir(pyver_root)? {
+        if let Some(path) = entry?.path().file_name() {
+            println!("{}", path.to_string_lossy());
+        }
     }
+    Ok(())
 }
 
-fn main() {
+fn main() -> Result<(), Box<dyn std::error::Error>>{
     let opt = PyVer::from_args();
     match opt {
-        PyVer::List { root } => command_list(root),
+        PyVer::List { root } => command_list(root)?,
     };
+    Ok(())
 }


### PR DESCRIPTION
1. `some_option.or_ok(thing)` evaluates to `Result::Err(thing)`, but
   that's not what you want for `pyver_root`! you want to fall back to
   the value of the environment variable...

2. ...but that can return `env::var::VarError` if the environment
   variable isn't present or isn't valid unicode; handle that by
   changing the return type of `command_list` to `Result` whose
   "error" side is a `std::err::Error` _trait object_ - a pointer to
   something that satisfies a trait.

3. Use `if let` to destructure the `Option` returned by
   `PathBuf.file_name()`, because it's `None` if the path is a
   directory.